### PR TITLE
Missing dependencies in dream-mirage

### DIFF
--- a/dream-mirage.opam
+++ b/dream-mirage.opam
@@ -55,6 +55,8 @@ depends: [
   "digestif" {>= "1.0.0"}
   "lwt"
   "tls-mirage"
+  "mirage-time"
+  "mirage-stack"
   "lwt_ppx" {>= "1.2.2"}
   "letsencrypt" {>= "0.3.0"}
 ]

--- a/dream-pure.opam
+++ b/dream-pure.opam
@@ -17,6 +17,7 @@ depends: [
   "dune" {>= "2.7.0"}  # --instrument-with.
   "hmap"
   "lwt"
+  "lwt_ppx"
   "multipart_form" {>= "0.3.0"}
   "ocaml" {>= "4.08.0"}
   "ptime" {>= "0.8.1"}  # Ptime.weekday.


### PR DESCRIPTION
I'm trying to set up a CI on ocaml-matrix, and encountered errors while building `dream-mirage`.
Here are the missing dependencies !